### PR TITLE
Do not expose physical path when 404'ing

### DIFF
--- a/Exceptions/WebDavNotFoundException.cs
+++ b/Exceptions/WebDavNotFoundException.cs
@@ -13,6 +13,15 @@ namespace WebDAVSharp.Server.Exceptions
         /// <summary>
         /// Initializes a new instance of the <see cref="WebDavNotFoundException" /> class.
         /// </summary>
+        public WebDavNotFoundException()
+            : base(HttpStatusCode.NotFound)
+        {
+            // Do nothing here
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebDavNotFoundException" /> class.
+        /// </summary>
         /// <param name="message">The exception message stating the reason for the exception being thrown.</param>
         /// <param name="innerException">The 
         /// <see cref="Exception" /> that is the cause for this exception;

--- a/MethodHandlers/WebDAVMethodHandlerBase.cs
+++ b/MethodHandlers/WebDAVMethodHandlerBase.cs
@@ -110,12 +110,8 @@ namespace WebDAVSharp.Server.MethodHandlers
             {
                 throw new WebDavUnauthorizedException();
             }
-            catch (WebDavNotFoundException wex)
-            {
-                throw new WebDavNotFoundException(String.Format("Cannot found name {0} from uri {1} father {2}", name, childUri, collection.ItemPath), wex);
-            }
             if (item == null)
-                throw new WebDavNotFoundException(String.Format("Cannot found name {0} from uri {1} father {2}", name, childUri, collection.ItemPath));
+                throw new WebDavNotFoundException();
 
             return item;
         }


### PR DESCRIPTION
This exception message is wholly unnecessary - the only thing it does is to inform the client of the request URI, as well as exposing the physical "ItemPath" of the collection, which could be seen as a security risk.

(The 404 response body on localhost/test used to be:)

    Cannot found name test from uri http://localhost:8080/test father C:\Dev\WebDAV server test\

Instead, now it will be just empty. Perhaps a "Not found" string would be in place here, though.